### PR TITLE
git_vsn for deps (tags)  and app_vsn for apps (.app.src)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@ Erlang advanced project manager
 
     {
         "name" : AppName,
-        "version" : AppVsn,
+        "app_vsn" : AppVsn,
         "drop_unknown_deps" : Boolean,
         "with_source" : Boolean,
         "deps" : [
             {
                 "name" : DepName,
                 "url" : DepUrl,
-                "vsn" : DepVsn
+                "tag" : GitTag
             }
         ],
         "prebuild" : [

--- a/coon/__init__.py
+++ b/coon/__init__.py
@@ -1,3 +1,3 @@
 APPNAME = 'coon'
 APPAUTHOR = 'Valerii Tikhonov'
-APPVSN = '0.8.0'
+APPVSN = '0.9.0'

--- a/coon/__main__.py
+++ b/coon/__main__.py
@@ -86,10 +86,10 @@ def do_build(builder):
     return builder.build()
 
 
-# Print project's version. Prefer coonfing.json vsn, but if none - use app.src version.
+# Print project's application version. Prefer coonfig.json vsn, but if none - use app.src version.
 def version(path):
     builder = Builder.init_from_path(path)
-    print(builder.project.vsn)
+    print(builder.project.vsn)  # TODO return vsn?
     return True
 
 

--- a/coon/pac_cache/artifactory_cache.py
+++ b/coon/pac_cache/artifactory_cache.py
@@ -41,7 +41,7 @@ class ArtifactoryCache(Cache):
         return path.exists()
 
     def get_package_path(self, package: Package):
-        return join(self.username, package.name, package.vsn, self.erlang_version)
+        return join(self.username, package.name, package.git_vsn, self.erlang_version)
 
     def add_package(self, package: Package, rewrite=True) -> bool:
         if not rewrite and self.exists(package):
@@ -62,4 +62,4 @@ class ArtifactoryCache(Cache):
         with path.open() as fd:
             with open(write_path, 'wb') as out:
                 out.write(fd.read())
-        dep.update_from_package(write_path, dep.url)  # TODO refactor me
+        dep.update_from_package(write_path)

--- a/coon/pac_cache/cache.py
+++ b/coon/pac_cache/cache.py
@@ -65,7 +65,7 @@ class Cache(metaclass=ABCMeta):
 
     def get_package_path(self, package: Package):
         namespace = package.url.split('/')[-2]
-        return join(namespace, package.name, package.vsn, self.erlang_version)
+        return join(namespace, package.name, package.git_vsn, self.erlang_version)
 
     @staticmethod
     def get_erlang_version():

--- a/coon/pac_cache/local_cache.py
+++ b/coon/pac_cache/local_cache.py
@@ -43,8 +43,8 @@ class LocalCache(Cache):
         if repo.bare:
             raise RuntimeError('Empty repo ' + dep.url)
         git = repo.git
-        git.checkout(dep.vsn)
-        repo.create_head(dep.vsn)
+        git.checkout(dep.git_vsn)
+        repo.create_head(dep.git_vsn)
         dep.update_from_cache(temp_path)
 
     # add built package to local cache, update its path

--- a/coon/packages/config/config.py
+++ b/coon/packages/config/config.py
@@ -14,17 +14,17 @@ def write_coonfig(path, package_config):
 
 
 class ConfigFile(metaclass=ABCMeta):
-    def __init__(self, vsn=None, url=None):
+    def __init__(self):
         self._prebuild = []
         self._build_vars = []
         self._c_build_vars = []
         self._deps = {}
-        self._conf_vsn = None
-        self._dep_vsn = vsn  # dep's version, when dep becomes package (after cache's fetch)
         self._with_source = True
         self._drop_unknown = True
         self._name = ''
-        self.__set_url(url)
+        self._conf_vsn = None
+        self._git_vsn = None
+        self._url = None
 
     @property
     def name(self) -> str:  # project's name
@@ -47,8 +47,12 @@ class ConfigFile(metaclass=ABCMeta):
         return self._conf_vsn
 
     @property
-    def dep_vsn(self) -> str or None:  # version from git (can be None in most cases)
-        return self._dep_vsn
+    def git_vsn(self) -> str or None:  # version from git (can be None in most cases)
+        return self._git_vsn
+
+    @git_vsn.setter
+    def git_vsn(self, vsn):
+        self._git_vsn = vsn
 
     @property
     def deps(self) -> dict:  # deps from config file. Dict of (url, vsn), where keys are their names
@@ -70,6 +74,10 @@ class ConfigFile(metaclass=ABCMeta):
     def url(self) -> str:
         return self._url
 
+    @url.setter
+    def url(self, url):
+        self._url = url
+
     @abstractmethod
     def get_compiler(self) -> Compiler:
         pass
@@ -77,12 +85,13 @@ class ConfigFile(metaclass=ABCMeta):
     def need_coonsify(self):
         return True
 
-    # TODO should take url from local repo if None. (Should do it only if adding to local cache).
-    def __set_url(self, url: str or None):
+    def set_url(self, url: str):
         self._url = url
 
-    def export(self):
-        return {'name': self.name,
-                'with_source': self.with_source,
-                'drop_unknown_deps': self.drop_unknown
+    def export(self) -> dict:
+        return {'with_source': self.with_source,
+                'drop_unknown_deps': self.drop_unknown,
+                'build_vars': self.build_vars,  # TODO skip if empty
+                'c_build_vars': self.c_build_vars,
+                'prebuild': self.prebuild
                 }

--- a/coon/packages/config/config_factory.py
+++ b/coon/packages/config/config_factory.py
@@ -8,14 +8,14 @@ from coon.packages.config.erlang_mk import ErlangMkConfig
 from coon.packages.config.rebar import RebarConfig
 
 
-def read_project(path: str, url=None, vsn=None) -> ConfigFile:
+def read_project(path: str, url=None) -> ConfigFile:
     files = get_files(path)
     if 'coonfig.json' in files:
-        return CoonConfig.from_path(path, vsn=vsn, url=url)
+        return CoonConfig.from_path(path, url=url)
     elif 'erlang.mk' in files:
-        return ErlangMkConfig(path, vsn=vsn, url=url)
+        return ErlangMkConfig(path, url=url)
     elif 'rebar.config' in files:
-        return RebarConfig(path, vsn=vsn, url=url)
+        return RebarConfig(path, url=url)
     raise ValueError("Unknown build system in project " + path)
 
 

--- a/coon/packages/config/coon.py
+++ b/coon/packages/config/coon.py
@@ -10,20 +10,22 @@ from coon.utils.file_utils import read_file
 
 
 class CoonConfig(ConfigFile):
-    def __init__(self, config: dict, vsn=None, url=None):
-        super().__init__(vsn=vsn, url=config.get('url', url))
+    def __init__(self, config: dict, url=None):
+        super().__init__()
         self._name = config['name']
         self._drop_unknown = config.get('drop_unknown_deps', True)
         self._with_source = config.get('with_source', True)
-        self._conf_vsn = config.get('version', None)
         self.__parse_prebuild(config)
         self.__parse_build_vars(config)
         self.__parse_deps(config.get('deps', {}))
+        self._conf_vsn = config.get('app_vsn', None)
+        self._git_vsn = config.get('tag', None)
+        self.set_url(config.get('url', url))
 
     @classmethod
-    def from_path(cls, path: str, url=None, vsn=None) -> 'CoonConfig':
+    def from_path(cls, path: str, url=None) -> 'CoonConfig':
         content = read_file(join(path, 'coonfig.json'))
-        return cls(json.loads(content), url=url, vsn=vsn)
+        return cls(json.loads(content), url=url)
 
     @classmethod
     def from_package(cls, package: TarFile, url: str) -> 'CoonConfig':
@@ -37,10 +39,10 @@ class CoonConfig(ConfigFile):
     def get_compiler(self):
         return Compiler.COON
 
-    def __parse_deps(self, deps):
+    def __parse_deps(self, deps: list):
         for dep in deps:
             name = dep['name']
-            self.deps[name] = (dep['url'], dep['vsn'])  # TODO need to create package here with DepConfig
+            self.deps[name] = (dep['url'], dep['tag'])
 
     def __parse_prebuild(self, parsed):
         for step in parsed.get('prebuild', []):

--- a/coon/packages/config/dep_config.py
+++ b/coon/packages/config/dep_config.py
@@ -3,8 +3,10 @@ from coon.packages.config.config import ConfigFile
 
 class DepConfig(ConfigFile):
     def __init__(self, name: str, vsn: str, url: str):
-        super().__init__(vsn=vsn, url=url)
+        super().__init__()
         self._name = name
+        self.set_url(url)
+        self._git_vsn = vsn
 
     def get_compiler(self):
         RuntimeError("Dep " + self.name + "can't be compiled")

--- a/coon/packages/config/erlang_mk.py
+++ b/coon/packages/config/erlang_mk.py
@@ -39,11 +39,12 @@ def get_dep(line):
 
 
 class ErlangMkConfig(ConfigFile):
-    def __init__(self, path: str, vsn=None, url=None):
-        super().__init__(vsn=vsn, url=url)
+    def __init__(self, path: str, url=None):
+        super().__init__()
         self._path = path
         makefile = join(path, 'Makefile')
         content = parse_makefile(makefile)
+        self.set_url(url)
         self.__conf_init(content)
         self.__parse_erl_opts(makefile, content)
         self.__parse_deps(content)

--- a/coon/packages/config/rebar.py
+++ b/coon/packages/config/rebar.py
@@ -8,11 +8,12 @@ from coon.utils.file_utils import read_file
 
 
 class RebarConfig(ConfigFile):
-    def __init__(self, path: str, vsn=None, url=None):
-        super().__init__(vsn=vsn, url=url)
+    def __init__(self, path: str, url=None):
+        super().__init__()
         self._path = path
         self._platform_defines = []
         rebarconfig = decode(read_file(join(path, 'rebar.config')))
+        self.set_url(url)
         self.__parse_config(rebarconfig)
 
     @property

--- a/coon/resources/templatecoonfig.json
+++ b/coon/resources/templatecoonfig.json
@@ -1,6 +1,6 @@
 {
   "name": "{{ name }}",
-  "version": "0.0.1",
+  "app_vsn": "0.0.1",
   "drop_unknown_deps": true,
   "with_source": true,
   "deps": [],

--- a/test/abs_test_class.py
+++ b/test/abs_test_class.py
@@ -1,11 +1,11 @@
 import json
+import test
 import unittest
+from os import listdir
 from os.path import join
 
 import os
-
-import test
-
+from git import Repo
 
 from coon.utils.file_utils import ensure_empty, remove_dir
 
@@ -59,3 +59,25 @@ class TestClass(unittest.TestCase):
 
     def tearDown(self):
         remove_dir(test.get_test_dir(self.test_name))
+
+
+def set_deps(path: str, deps: list):
+    fullpath = join(path, 'coonfig.json')
+    with open(fullpath, 'r') as file:
+        conf = json.load(file)
+    conf['deps'] = deps
+    with open(fullpath, 'w') as file:
+        json.dump(conf, file)
+
+
+def set_git_url(path: str, url: str):
+    repo = Repo.init(path)
+    repo.index.add(listdir(path))
+    repo.index.commit("First commit")
+    repo.create_head('master')
+    repo.create_remote('origin', url=url + '.git')
+
+
+def set_git_tag(path: str, tag: str):
+    repo = Repo(path)
+    repo.create_tag(tag, message='new tag')

--- a/test/test_applications.py
+++ b/test/test_applications.py
@@ -29,7 +29,7 @@ class ApplicationsTests(TestClass):
         with open(join(self.test_dir, 'coonfig.json'), 'w') as w:
             w.write(get_package_conf([{'name': 'test_dep',
                                        'url': "test_url",
-                                       'vsn': "test_vsn"}]))
+                                       'tag': "test_vsn"}]))
         package = Package.from_path(self.test_dir)
         # test_dep in package deps (from package conf)
         self.assertEqual(['test_dep'], [dep.name for dep in package.deps])
@@ -54,7 +54,7 @@ class ApplicationsTests(TestClass):
         with open(join(self.test_dir, 'coonfig.json'), 'w') as w:
             w.write(get_package_conf([{'name': 'test_dep',
                                        'url': "test_url",
-                                       'vsn': "test_vsn"}]))
+                                       'tag': "test_vsn"}]))
         package = Package.from_path(self.test_dir)
         # test_dep in package deps (from package conf)
         self.assertEqual(['test_dep'], [dep.name for dep in package.deps])
@@ -71,10 +71,10 @@ class ApplicationsTests(TestClass):
         with open(join(self.test_dir, 'coonfig.json'), 'w') as w:
             w.write(get_package_conf([{'name': 'test_dep1',
                                        'url': "test_url",
-                                       'vsn': "test_vsn"},
+                                       'tag': "test_vsn"},
                                       {'name': 'test_dep3',
                                        'url': "test_url",
-                                       'vsn': "test_vsn"}]))
+                                       'tag': "test_vsn"}]))
         package = Package.from_path(self.test_dir)
         package_deps = [dep.name for dep in package.deps]
         self.assertEqual(2, len(package_deps))

--- a/test/test_artifactory_cache.py
+++ b/test/test_artifactory_cache.py
@@ -8,7 +8,7 @@ from mock import patch
 from coon.__main__ import create, package
 from coon.packages.package import Package
 from coon.packages.package_builder import Builder
-from test.abs_test_class import TestClass
+from test.abs_test_class import TestClass, set_git_url, set_git_tag
 
 
 # Artifactory should be available locally on path
@@ -55,6 +55,8 @@ class ArtifactoryTests(TestClass):
     def test_simple_uploading(self, mock_conf):
         mock_conf.return_value = self.conf_file
         pack_path = join(self.test_dir, 'test_project')
+        set_git_url(pack_path, 'http://github/comtihon/test_project')
+        set_git_tag(pack_path, '1.0.0')
         pack = Package.from_path(pack_path)
         package(pack_path)
         builder = Builder.init_from_path(pack_path)
@@ -67,6 +69,8 @@ class ArtifactoryTests(TestClass):
     def test_exists(self, mock_conf):
         mock_conf.return_value = self.conf_file
         pack_path = join(self.test_dir, 'test_project')
+        set_git_url(pack_path, 'http://github/comtihon/test_project')
+        set_git_tag(pack_path, '1.0.0')
         pack = Package.from_path(pack_path)
         builder = Builder.init_from_path(pack_path)
         exists = ArtifactoryTests.check_exists(builder.system_config.cache.remote_caches, pack)

--- a/test/test_coon_compiler.py
+++ b/test/test_coon_compiler.py
@@ -91,10 +91,10 @@ class CompileTests(TestClass):
         with open(join(self.test_dir, 'coonfig.json'), 'w') as w:
             w.write('''{
             \"name\":\"proper\",
-            \"version\":\"1.0.0\",
+            \"app_vsn\":\"1.0.0\",
             \"deps\": [{\"name\": \"test_dep\",
                         \"url\": \"test_url\",
-                        \"vsn\": \"test_vsn\"}]
+                        \"tag\": \"test_vsn\"}]
             }''')
         package = Package.from_path(self.test_dir)
         compiler = CoonCompiler(package)

--- a/test/test_local_cache.py
+++ b/test/test_local_cache.py
@@ -11,7 +11,7 @@ from coon.pac_cache.local_cache import LocalCache
 from coon.packages.package import Package
 from coon.packages.package_builder import Builder
 from coon.utils.file_utils import remove_dir, copy_file
-from test.abs_test_class import TestClass
+from test.abs_test_class import TestClass, set_deps, set_git_url, set_git_tag
 
 
 def mock_fetch_package(dep: Package):
@@ -35,7 +35,8 @@ class LocalCacheTests(TestClass):
     def test_package_exists(self, mock_conf):
         mock_conf.return_value = self.conf_file
         pack_path = join(self.test_dir, 'test_app')
-        set_url(pack_path, 'https://github.com/comtihon/test_app')
+        set_git_url(pack_path, 'http://github/comtihon/test_app')
+        set_git_tag(pack_path, '1.0.0')
         pack = Package.from_path(pack_path)
         builder = Builder.init_from_path(pack_path)
         self.assertEqual(False, builder.system_config.cache.exists_local(pack))
@@ -48,7 +49,8 @@ class LocalCacheTests(TestClass):
     def test_add_from_package(self, mock_conf):
         mock_conf.return_value = self.conf_file
         pack_path = join(self.test_dir, 'test_app')
-        set_url(pack_path, 'https://github.com/comtihon/test_app')
+        set_git_url(pack_path, 'http://github/comtihon/test_app')
+        set_git_tag(pack_path, '1.0.0')
         builder = Builder.init_from_path(pack_path)
         self.assertEqual(True, builder.build())
         builder.package()
@@ -68,7 +70,8 @@ class LocalCacheTests(TestClass):
     def test_add_from_path(self, mock_conf):
         mock_conf.return_value = self.conf_file
         pack_path = join(self.test_dir, 'test_app')
-        set_url(pack_path, 'https://github.com/comtihon/test_app')
+        set_git_url(pack_path, 'http://github/comtihon/test_app')
+        set_git_tag(pack_path, '1.0.0')
         builder = Builder.init_from_path(pack_path)
         self.assertEqual(True, builder.build())
         self.assertEqual(False, builder.system_config.cache.exists_local(builder.project))
@@ -86,30 +89,29 @@ class LocalCacheTests(TestClass):
         mock_conf.return_value = self.conf_file
         # Create test_app with deps: A and B
         pack_path = join(self.test_dir, 'test_app')
+        set_git_url(pack_path, 'http://github/comtihon/test_app')
+        set_git_tag(pack_path, '1.0.0')
         set_deps(pack_path,
                  [
                      {'name': 'a_with_dep_a2',
                       'url': 'https://github.com/comtihon/a_with_dep_a2',
-                      'vsn': '1.0.0'},
+                      'tag': '1.0.0'},
                      {'name': 'b_with_no_deps',
                       'url': 'https://github.com/comtihon/b_with_no_deps',
-                      'vsn': '1.0.0'}
+                      'tag': '1.0.0'}
                  ])
         # Create dep A with dep A2 (in tmp, as if we download them from git)
         create(self.tmp_dir, {'<name>': 'a_with_dep_a2'})
         dep_a1_path = join(self.tmp_dir, 'a_with_dep_a2')
-        set_url(dep_a1_path, 'https://github.com/comtihon/a_with_dep_a2')
         set_deps(dep_a1_path, [{'name': 'a2_with_no_deps',
                                 'url': 'https://github.com/comtihon/a2_with_no_deps',
-                                'vsn': '1.0.0'}])
+                                'tag': '1.0.0'}])
         # Create dep B (in tmp, as if we download them from git)
         create(self.tmp_dir, {'<name>': 'b_with_no_deps'})
         dep_b_path = join(self.tmp_dir, 'b_with_no_deps')
-        set_url(dep_b_path, 'https://github.com/comtihon/b_with_no_deps')
         # Create dep A2 (in tmp, as if we download them from git)
         create(self.tmp_dir, {'<name>': 'a2_with_no_deps'})
         dep_a2_path = join(self.tmp_dir, 'a2_with_no_deps')
-        set_url(dep_a2_path, 'https://github.com/comtihon/a2_with_no_deps')
         # Compile test_project
         builder = Builder.init_from_path(pack_path)
         self.assertEqual(False, builder.system_config.cache.exists_local(Package.from_path(dep_a1_path)))
@@ -120,24 +122,6 @@ class LocalCacheTests(TestClass):
         self.assertEqual(True, builder.system_config.cache.exists_local(Package.from_path(dep_a1_path)))
         self.assertEqual(True, builder.system_config.cache.exists_local(Package.from_path(dep_b_path)))
         self.assertEqual(True, builder.system_config.cache.exists_local(Package.from_path(dep_a2_path)))
-
-
-def set_url(path: str, url: str):
-    fullpath = join(path, 'coonfig.json')
-    with open(fullpath, 'r') as file:
-        conf = json.load(file)
-    conf['url'] = url
-    with open(fullpath, 'w') as file:
-        json.dump(conf, file)
-
-
-def set_deps(path: str, deps: list):
-    fullpath = join(path, 'coonfig.json')
-    with open(fullpath, 'r') as file:
-        conf = json.load(file)
-    conf['deps'] = deps
-    with open(fullpath, 'w') as file:
-        json.dump(conf, file)
 
 
 if __name__ == '__main__':

--- a/test/test_packages.py
+++ b/test/test_packages.py
@@ -1,0 +1,79 @@
+import unittest
+from os.path import join
+
+from mock import patch
+
+from coon.__main__ import create
+from coon.packages.package import Package
+from coon.packages.package_builder import Builder
+from test.abs_test_class import TestClass, set_git_url, set_git_tag
+
+
+class PackageTests(TestClass):
+    def __init__(self, method_name):
+        super().__init__('package_tests', method_name)
+
+    # Package can be created from path. Usually by opening package source paths when working with project.
+    def test_init_from_path(self):
+        create(self.test_dir, {'<name>': 'test_app'})
+        set_git_url(join(self.test_dir, 'test_app'), 'http://github/my_namespace/my_project')
+        set_git_tag(join(self.test_dir, 'test_app'), '1.0.0')
+        pack = Package.from_path(join(self.test_dir, 'test_app'))
+        self.assertEqual('test_app', pack.name)
+        self.assertEqual('0.0.1', pack.vsn)
+        self.assertEqual('http://github/my_namespace/my_project.git', pack.url)
+        self.assertEqual('1.0.0', pack.git_vsn)
+        self.assertEqual([], pack.deps)
+
+    # Package can be created from dep. Usually when populating main project deps.
+    def test_init_from_dep(self):
+        pack = Package.from_dep('test_app', ('some_url', '1.0.0'))
+        self.assertEqual([], pack.deps)
+        self.assertEqual('test_app', pack.name)
+        self.assertEqual('1.0.0', pack.git_vsn)
+
+    # Main project's dep can be fetched and filled.
+    def test_update_from_cache(self):
+        pack = Package.from_dep('my_dep', ('some_url', '1.0.0'))
+        create(self.test_dir, {'<name>': 'my_dep'})
+        pack.update_from_cache(join(self.test_dir, 'my_dep'))
+        self.assertEqual('my_dep', pack.name)
+        self.assertEqual('0.0.1', pack.vsn)
+        self.assertEqual('1.0.0', pack.git_vsn)
+        self.assertEqual('some_url', pack.url)
+        self.assertEqual([], pack.deps)
+
+    # Package can be created from coon package tar file. Is usually called on manually load package to remote repo
+    @patch('coon.global_properties.ensure_conf_file')
+    def test_init_from_package(self, mock_conf):
+        mock_conf.return_value = self.conf_file
+        create(self.test_dir, {'<name>': 'my_dep'})
+        pack_path = join(self.test_dir, 'my_dep')
+        builder = Builder.init_from_path(pack_path)
+        self.assertEqual(True, builder.build())
+        builder.package()
+        pack = Package.from_package(join(pack_path, 'my_dep.cp'))
+        self.assertEqual('my_dep', pack.name)
+        self.assertEqual('0.0.1', pack.vsn)
+        self.assertEqual([], pack.deps)
+
+    # Package can be updated from coon package tar file, which was downloaded from dep.
+    @patch('coon.global_properties.ensure_conf_file')
+    def test_update_from_package(self, mock_conf):
+        mock_conf.return_value = self.conf_file
+        create(self.test_dir, {'<name>': 'my_dep'})
+        pack_path = join(self.test_dir, 'my_dep')
+        builder = Builder.init_from_path(pack_path)
+        self.assertEqual(True, builder.build())
+        builder.package()
+        pack = Package.from_dep('my_dep', ('some_url', '1.0.0'))
+        pack.update_from_package(join(pack_path, 'my_dep.cp'))
+        self.assertEqual('my_dep', pack.name)
+        self.assertEqual('0.0.1', pack.vsn)
+        self.assertEqual('1.0.0', pack.git_vsn)
+        self.assertEqual('some_url', pack.url)
+        self.assertEqual([], pack.deps)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
* git_vsn as main version used in cache actions.
* app_vsn as `.app.src` erlang app version
* add tests
* take url and vsn (tags only) from local git