### PR TITLE
made deps auto updating

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![PyPI](https://img.shields.io/pypi/wheel/coon.svg)](https://pypi.python.org/pypi/coon)  
 Erlang advanced project manager.  
 _Why Coon?_  
-- deps auto removing
+- powerful dependency management
 - built deps caching locally and remotely
 - json project configuration
 - Jinja2 templating
@@ -106,6 +106,13 @@ it is simple, well known, and can be easily accessed by third-party tools:
 Although it is not recommended, but you can use [Erlang.mk](https://erlang.mk/) or `rebar.config` as a project config. 
 For now only version, name and deps can be used.
 
+### Dependency management
+* speficy deps in coonfig
+* deps update if tag changed in coonfig
+* deps auto update if newer dep presents in dependency tree
+* deps auto removing if dep is not used any more
+TODO link on article
+
 ### Jinja2 templating
 Coon allows you to use [Jinja2](http://jinja.pocoo.org/) template engine in your config files:  
 __app.src__
@@ -121,9 +128,9 @@ __app.src__
     ]}.
 Where `modules` are the list of all application's modules and `app` is the object of Package class from 
 `coon/packages/package.py` representing current project. You can use it's properties in templating.  
-In `app.src` you have also `hostname` available for templating.    
+In `app.src` you have also `hostname` available for templating. Read more in the full 
+[article](https://justtech.blog/2017/06/01/dynamic-configuration-erlang/).    
 
-TODO example or full doc here.  
 __relx.config__
 
     {release, {"{{ app.name }}", "{{ app.vsn }}"}, ["{{ app.name }}"]}.

--- a/coon/__init__.py
+++ b/coon/__init__.py
@@ -1,3 +1,3 @@
 APPNAME = 'coon'
 APPAUTHOR = 'Valerii Tikhonov'
-APPVSN = '0.10.0'
+APPVSN = '0.11.0'

--- a/test/test_deps.py
+++ b/test/test_deps.py
@@ -1,0 +1,298 @@
+import unittest
+from os.path import join
+
+import os
+from mock import patch
+
+import test
+from coon.__main__ import create
+from coon.pac_cache.local_cache import LocalCache
+from coon.packages.package import Package
+from coon.packages.package_builder import Builder
+from test.abs_test_class import TestClass, set_deps
+
+
+def mock_fetch_package(dep: Package):
+    test_dir = test.get_test_dir('deps_tests')
+    tmp_path = join(os.getcwd(), test_dir, 'tmp')
+    if dep.name == 'update_dep' and dep.git_vsn == '1.2.0':
+        set_deps(join(tmp_path, dep.name),
+                 [
+                     {'name': 'dep3',
+                      'url': 'https://github.com/comtihon/dep3',
+                      'tag': '1.0.0'}
+                 ])
+    if dep.name == 'remove_dep' and dep.git_vsn == '1.2.0':
+        set_deps(join(tmp_path, dep.name), [])
+    dep.update_from_cache(join(tmp_path, dep.name))
+
+
+class DepsTests(TestClass):
+    def __init__(self, method_name):
+        super().__init__('deps_tests', method_name)
+
+    def setUp(self):
+        super().setUp()
+        create(self.test_dir, {'<name>': 'test_app'})
+
+    # Test if deps and deps of deps are fetched properly
+    @patch.object(LocalCache, 'fetch_package')
+    @patch('coon.global_properties.ensure_conf_file')
+    def test_deps_fetch(self, mock_conf, mock_fetch):
+        mock_conf.return_value = self.conf_file
+        mock_fetch.side_effect = mock_fetch_package
+        pack_path = join(self.test_dir, 'test_app')
+        set_deps(pack_path,
+                 [
+                     {'name': 'dep1',
+                      'url': 'https://github.com/comtihon/dep1',
+                      'tag': '1.0.0'},
+                     {'name': 'dep2',
+                      'url': 'https://github.com/comtihon/dep2',
+                      'tag': '1.0.0'}
+                 ])
+        create(self.tmp_dir, {'<name>': 'dep1'})
+        create(self.tmp_dir, {'<name>': 'dep2'})
+        dep_tmp_path = join(self.tmp_dir, 'dep2')
+        set_deps(dep_tmp_path,
+                 [
+                     {'name': 'dep3',
+                      'url': 'https://github.com/comtihon/dep3',
+                      'tag': '1.0.0'}
+                 ])
+        create(self.tmp_dir, {'<name>': 'dep3'})
+        builder = Builder.init_from_path(pack_path)
+        builder.populate()
+        self.assertEqual(['dep1', 'dep2', 'dep3'], list(builder.packages.keys()))
+        self.assertEqual(mock_fetch.call_count, 3)
+
+    # Test if some deps have same deps and they won't be fetched again
+    @patch.object(LocalCache, 'fetch_package')
+    @patch('coon.global_properties.ensure_conf_file')
+    def test_deps_duplicates(self, mock_conf, mock_fetch):
+        mock_conf.return_value = self.conf_file
+        mock_fetch.side_effect = mock_fetch_package
+        pack_path = join(self.test_dir, 'test_app')
+        set_deps(pack_path,
+                 [
+                     {'name': 'dep1',
+                      'url': 'https://github.com/comtihon/dep1',
+                      'tag': '1.0.0'},
+                     {'name': 'dep2',
+                      'url': 'https://github.com/comtihon/dep2',
+                      'tag': '1.0.0'}
+                 ])
+        create(self.tmp_dir, {'<name>': 'dep1'})
+        dep_tmp_path = join(self.tmp_dir, 'dep1')  # Here dep1 and dep2 have common dep3
+        set_deps(dep_tmp_path,
+                 [
+                     {'name': 'dep3',
+                      'url': 'https://github.com/comtihon/dep3',
+                      'tag': '1.0.0'}
+                 ])
+        create(self.tmp_dir, {'<name>': 'dep2'})
+        dep_tmp_path = join(self.tmp_dir, 'dep2')
+        set_deps(dep_tmp_path,
+                 [
+                     {'name': 'dep3',
+                      'url': 'https://github.com/comtihon/dep3',
+                      'tag': '1.0.0'}
+                 ])
+        create(self.tmp_dir, {'<name>': 'dep3'})
+        builder = Builder.init_from_path(pack_path)
+        builder.populate()
+        self.assertEqual(['dep1', 'dep2', 'dep3'], list(builder.packages.keys()))
+        self.assertEqual(mock_fetch.call_count, 3)  # dep3 was fetched only once
+
+    # Test if some low level deps require up level deps
+    @patch.object(LocalCache, 'fetch_package')
+    @patch('coon.global_properties.ensure_conf_file')
+    def test_circular_deps(self, mock_conf, mock_fetch):
+        mock_conf.return_value = self.conf_file
+        mock_fetch.side_effect = mock_fetch_package
+        pack_path = join(self.test_dir, 'test_app')
+        set_deps(pack_path,
+                 [
+                     {'name': 'dep1',
+                      'url': 'https://github.com/comtihon/dep1',
+                      'tag': '1.0.0'},
+                     {'name': 'dep2',
+                      'url': 'https://github.com/comtihon/dep2',
+                      'tag': '1.0.0'}
+                 ])
+        create(self.tmp_dir, {'<name>': 'dep1'})
+        create(self.tmp_dir, {'<name>': 'dep2'})
+        dep_tmp_path = join(self.tmp_dir, 'dep2')
+        set_deps(dep_tmp_path,
+                 [
+                     {'name': 'dep3',
+                      'url': 'https://github.com/comtihon/dep3',
+                      'tag': '1.0.0'}
+                 ])
+        create(self.tmp_dir, {'<name>': 'dep3'})
+        dep_tmp_path = join(self.tmp_dir, 'dep3')
+        set_deps(dep_tmp_path,  # dep3 require dep1, which was included in root.
+                 [
+                     {'name': 'dep1',
+                      'url': 'https://github.com/comtihon/dep1',
+                      'tag': '1.0.0'}
+                 ])
+        builder = Builder.init_from_path(pack_path)
+        builder.populate()
+        self.assertEqual(['dep1', 'dep2', 'dep3'], list(builder.packages.keys()))
+        self.assertEqual(mock_fetch.call_count, 3)  # dep1 was fetched only once
+
+    # Test if root has newer dep and it will be selected over old version (if they are not in conflict)
+    @patch.object(LocalCache, 'fetch_package')
+    @patch('coon.global_properties.ensure_conf_file')
+    def test_dep_override_newer(self, mock_conf, mock_fetch):
+        mock_conf.return_value = self.conf_file
+        mock_fetch.side_effect = mock_fetch_package
+        pack_path = join(self.test_dir, 'test_app')
+        set_deps(pack_path,
+                 [
+                     {'name': 'dep2',
+                      'url': 'https://github.com/comtihon/dep2',
+                      'tag': '1.0.0'},
+                     {'name': 'dep3',
+                      'url': 'https://github.com/comtihon/dep3',
+                      'tag': '1.0.1'}
+                 ])
+        create(self.tmp_dir, {'<name>': 'dep2'})
+        dep_tmp_path = join(self.tmp_dir, 'dep2')
+        set_deps(dep_tmp_path,
+                 [
+                     {'name': 'dep3',
+                      'url': 'https://github.com/comtihon/dep3',
+                      'tag': '1.0.0'}
+                 ])
+        create(self.tmp_dir, {'<name>': 'dep3'})
+        builder = Builder.init_from_path(pack_path)
+        builder.populate()
+        self.assertEqual(['dep2', 'dep3'], list(builder.packages.keys()))
+        self.assertEqual(mock_fetch.call_count, 2)
+        self.assertEqual('1.0.0', builder.packages['dep2'].git_vsn)
+        self.assertEqual('1.0.1', builder.packages['dep3'].git_vsn)
+
+    # Test if some deps have conflicting versions
+    @patch.object(LocalCache, 'fetch_package')
+    @patch('coon.global_properties.ensure_conf_file')
+    def test_deps_conflict(self, mock_conf, mock_fetch):
+        mock_conf.return_value = self.conf_file
+        mock_fetch.side_effect = mock_fetch_package
+        pack_path = join(self.test_dir, 'test_app')
+        set_deps(pack_path,
+                 [
+                     {'name': 'dep1',
+                      'url': 'https://github.com/comtihon/dep1',
+                      'tag': '1.0.0'},
+                     {'name': 'dep2',
+                      'url': 'https://github.com/comtihon/dep2',
+                      'tag': '1.0.0'},
+                     {'name': 'dep3',
+                      'url': 'https://github.com/comtihon/dep3',
+                      'tag': '2.0.0'}
+                 ])
+        create(self.tmp_dir, {'<name>': 'dep1'})
+        create(self.tmp_dir, {'<name>': 'dep2'})
+        dep_tmp_path = join(self.tmp_dir, 'dep2')
+        set_deps(dep_tmp_path,
+                 [
+                     {'name': 'dep3',
+                      'url': 'https://github.com/comtihon/dep3',
+                      'tag': '1.0.0'}
+                 ])
+        create(self.tmp_dir, {'<name>': 'dep3'})
+        builder = Builder.init_from_path(pack_path)
+        try:  # builder population should fail, because of conflicting dependencies.
+            builder.populate()
+            populated = True
+        except RuntimeError:
+            populated = False
+        self.assertEqual(False, populated)
+
+    # Test if newer deps will be prefered over old one if difference is not major
+    @patch.object(LocalCache, 'fetch_package')
+    @patch('coon.global_properties.ensure_conf_file')
+    def test_deps_prefer_newer(self, mock_conf, mock_fetch):
+        mock_conf.return_value = self.conf_file
+        mock_fetch.side_effect = mock_fetch_package
+        pack_path = join(self.test_dir, 'test_app')
+        set_deps(pack_path,
+                 [
+                     {'name': 'dep1',
+                      'url': 'https://github.com/comtihon/dep1',
+                      'tag': '1.0.0'},
+                     {'name': 'dep2',
+                      'url': 'https://github.com/comtihon/dep2',
+                      'tag': '1.0.0'},
+                     {'name': 'dep3',
+                      'url': 'https://github.com/comtihon/dep2',
+                      'tag': '1.0.0'},
+                     {'name': 'dep4',
+                      'url': 'https://github.com/comtihon/dep4',
+                      'tag': '1.0.0'}
+                 ])
+        create(self.tmp_dir, {'<name>': 'dep1'})
+        dep_tmp_path = join(self.tmp_dir, 'dep1')
+        set_deps(dep_tmp_path,
+                 [
+                     {'name': 'dep4',
+                      'url': 'https://github.com/comtihon/dep4',
+                      'tag': '1.0.1'}  # has newer version then root
+                 ])
+        create(self.tmp_dir, {'<name>': 'dep2'})
+        dep_tmp_path = join(self.tmp_dir, 'dep2')
+        set_deps(dep_tmp_path,
+                 [
+                     {'name': 'dep3',
+                      'url': 'https://github.com/comtihon/dep3',
+                      'tag': '1.1.0'}  # has newer version then root
+                 ])
+        create(self.tmp_dir, {'<name>': 'dep3'})
+        create(self.tmp_dir, {'<name>': 'dep4'})
+        builder = Builder.init_from_path(pack_path)
+        builder.populate()
+        self.assertEqual(['dep1', 'dep2', 'dep3', 'dep4'], list(builder.packages.keys()))
+        self.assertEqual(mock_fetch.call_count, 6)  # root's deps were fetched, than 2 new deps were fetched
+        self.assertEqual('1.0.0', builder.packages['dep1'].git_vsn)
+        self.assertEqual('1.0.0', builder.packages['dep2'].git_vsn)
+        self.assertEqual('1.1.0', builder.packages['dep3'].git_vsn)
+        self.assertEqual('1.0.1', builder.packages['dep4'].git_vsn)
+
+    # Test if newer dep has new dep which should also be fetched
+    @patch.object(LocalCache, 'fetch_package')
+    @patch('coon.global_properties.ensure_conf_file')
+    def test_deps_prefer_newer_new_dep(self, mock_conf, mock_fetch):
+        mock_conf.return_value = self.conf_file
+        mock_fetch.side_effect = mock_fetch_package
+        pack_path = join(self.test_dir, 'test_app')
+        set_deps(pack_path,
+                 [
+                     {'name': 'update_dep',
+                      'url': 'https://github.com/comtihon/update_dep',
+                      'tag': '1.0.0'},  # has no deps in 1.0.0
+                     {'name': 'dep2',
+                      'url': 'https://github.com/comtihon/dep2',
+                      'tag': '1.0.0'}  # dep2 has update_dep 1.2.0 in deps
+                 ])
+        create(self.tmp_dir, {'<name>': 'dep2'})
+        dep_tmp_path = join(self.tmp_dir, 'dep2')
+        set_deps(dep_tmp_path,
+                 [
+                     {'name': 'update_dep',
+                      'url': 'https://github.com/comtihon/update_dep',
+                      'tag': '1.2.0'}  # has newer version then root
+                 ])
+        create(self.tmp_dir, {'<name>': 'update_dep'})  # dep3 will be added as a dep in 1.2.0 (see mock_fetch_package)
+        create(self.tmp_dir, {'<name>': 'dep3'})
+        builder = Builder.init_from_path(pack_path)
+        builder.populate()
+        self.assertEqual(['update_dep', 'dep2', 'dep3'], list(builder.packages.keys()))
+        self.assertEqual('1.0.0', builder.packages['dep2'].git_vsn)
+        self.assertEqual('1.2.0', builder.packages['update_dep'].git_vsn)
+        self.assertEqual('1.0.0', builder.packages['dep3'].git_vsn)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_deps.py
+++ b/test/test_deps.py
@@ -63,7 +63,7 @@ class DepsTests(TestClass):
         create(self.tmp_dir, {'<name>': 'dep3'})
         builder = Builder.init_from_path(pack_path)
         builder.populate()
-        self.assertEqual(['dep1', 'dep2', 'dep3'], list(builder.packages.keys()))
+        self.assertEqual(['dep1', 'dep2', 'dep3'].sort(), list(builder.packages.keys()).sort())
         self.assertEqual(mock_fetch.call_count, 3)
 
     # Test if some deps have same deps and they won't be fetched again
@@ -101,7 +101,7 @@ class DepsTests(TestClass):
         create(self.tmp_dir, {'<name>': 'dep3'})
         builder = Builder.init_from_path(pack_path)
         builder.populate()
-        self.assertEqual(['dep1', 'dep2', 'dep3'], list(builder.packages.keys()))
+        self.assertEqual(['dep1', 'dep2', 'dep3'].sort(), list(builder.packages.keys()).sort())
         self.assertEqual(mock_fetch.call_count, 3)  # dep3 was fetched only once
 
     # Test if some low level deps require up level deps
@@ -139,7 +139,7 @@ class DepsTests(TestClass):
                  ])
         builder = Builder.init_from_path(pack_path)
         builder.populate()
-        self.assertEqual(['dep1', 'dep2', 'dep3'], list(builder.packages.keys()))
+        self.assertEqual(['dep1', 'dep2', 'dep3'].sort(), list(builder.packages.keys()).sort())
         self.assertEqual(mock_fetch.call_count, 3)  # dep1 was fetched only once
 
     # Test if root has newer dep and it will be selected over old version (if they are not in conflict)
@@ -169,7 +169,7 @@ class DepsTests(TestClass):
         create(self.tmp_dir, {'<name>': 'dep3'})
         builder = Builder.init_from_path(pack_path)
         builder.populate()
-        self.assertEqual(['dep2', 'dep3'], list(builder.packages.keys()))
+        self.assertEqual(['dep2', 'dep3'].sort(), list(builder.packages.keys()).sort())
         self.assertEqual(mock_fetch.call_count, 2)
         self.assertEqual('1.0.0', builder.packages['dep2'].git_vsn)
         self.assertEqual('1.0.1', builder.packages['dep3'].git_vsn)
@@ -253,7 +253,7 @@ class DepsTests(TestClass):
         create(self.tmp_dir, {'<name>': 'dep4'})
         builder = Builder.init_from_path(pack_path)
         builder.populate()
-        self.assertEqual(['dep1', 'dep2', 'dep3', 'dep4'], list(builder.packages.keys()))
+        self.assertEqual(['dep1', 'dep2', 'dep3', 'dep4'].sort(), list(builder.packages.keys()).sort())
         self.assertEqual(mock_fetch.call_count, 6)  # root's deps were fetched, than 2 new deps were fetched
         self.assertEqual('1.0.0', builder.packages['dep1'].git_vsn)
         self.assertEqual('1.0.0', builder.packages['dep2'].git_vsn)
@@ -288,7 +288,7 @@ class DepsTests(TestClass):
         create(self.tmp_dir, {'<name>': 'dep3'})
         builder = Builder.init_from_path(pack_path)
         builder.populate()
-        self.assertEqual(['update_dep', 'dep2', 'dep3'], list(builder.packages.keys()))
+        self.assertEqual(['update_dep', 'dep2', 'dep3'].sort(), list(builder.packages.keys()).sort())
         self.assertEqual('1.0.0', builder.packages['dep2'].git_vsn)
         self.assertEqual('1.2.0', builder.packages['update_dep'].git_vsn)
         self.assertEqual('1.0.0', builder.packages['dep3'].git_vsn)


### PR DESCRIPTION
Root project has depA (1.0.0) and depB(1.0.0)
If depA has depC(1.0.0) which also has depB(1.2.0) - newer vsn of depB will be preferred.
Major difference in version will lead to exception, as such conflicts should be resolved manually.
Minor and feature differences will be picked.
If newer dep has also new dep (f.e. depB has got depD in (1.2.0)) - new dep will also be fetched. 