### PR TITLE
added test deps support + test

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,13 @@ Coon configuration file is `coonfig.json`, it is placed in project_dir. It is in
                 "tag" : GitTag / "branch" : BranchName
             }
         ],
+        "test_deps" : [
+            {
+                "name" : DepName,
+                "url" : DepUrl,
+                "tag" : GitTag / "branch" : BranchName
+            }
+        ],
         "prebuild" : [
             {Action : Params}
         ],
@@ -89,6 +96,7 @@ remove dead deps from deps directory. You can set it to false if you prefer manu
 `deps` is a list of deps, where `dep.name` is a name of dep, `dep.url` is a full url to dep. If it is not specified - 
 url will be fetched from [hex](https://hex.pm/), `dep.tag` is a tag of a dep and `dep.branch` is a branch. 
 Last two are mutually exclusive. Only git deps are supported now.  
+`test_deps` is the same, that `deps`, but are built, fetched and linked only for ct/eunit.  
 `prebuild` is a list of actions, which should be run before build. `prebuild.Action` is a type of the action. 
 Only `shell` is supported now. `prebuild.Params` are the options to be passed to action. TODO example here.  
 `build_vars` is a list of erlang build vars, used when building a project. They can be either single or with value: 

--- a/coon/__init__.py
+++ b/coon/__init__.py
@@ -1,3 +1,3 @@
 APPNAME = 'coon'
 APPAUTHOR = 'Valerii Tikhonov'
-APPVSN = '0.13.1'
+APPVSN = '0.14.0'

--- a/coon/__main__.py
+++ b/coon/__main__.py
@@ -34,8 +34,8 @@ from pkg_resources import Requirement, resource_filename
 
 from coon import APPVSN
 from coon.packages.package_builder import Builder
-from coon.utils.file_utils import ensure_dir
 from coon.utils import logger
+from coon.utils.file_utils import ensure_dir
 
 
 def main(args=None):
@@ -91,8 +91,8 @@ def build(path):
     return do_build(builder)
 
 
-def do_build(builder):
-    builder.populate()
+def do_build(builder: Builder, test=False):
+    builder.populate(test)
     return builder.build()
 
 
@@ -145,7 +145,7 @@ def add_package(path, arguments):
 # Run tests
 def eunit(path):
     builder = Builder.init_from_path(path)
-    if not do_build(builder):
+    if not do_build(builder, test=True):
         return False
     return builder.unit_test()
 
@@ -153,7 +153,7 @@ def eunit(path):
 def ct(path, arguments):
     log_dir = arguments['--log-dir']
     builder = Builder.init_from_path(path)
-    if not do_build(builder):
+    if not do_build(builder, test=True):
         return False
     return builder.common_test(log_dir)
 

--- a/coon/compiler/coon.py
+++ b/coon/compiler/coon.py
@@ -65,7 +65,7 @@ class CoonCompiler(AbstractCompiler):
         all_src = self.__get_all_files(self.test_path, 'erl')
         ensure_dir(self.output_path)
         if self.__do_compile(all_src, output=self.test_path):
-            modules, test_dirs = self.__get_test_directories(all_src, '_SUITE')
+            modules, test_dirs = self.__get_test_directories(all_src, drop_extension='_SUITE')
             return self.__do_unit_test(modules, test_dirs)
         return False
 

--- a/coon/packages/config/config.py
+++ b/coon/packages/config/config.py
@@ -36,6 +36,7 @@ class ConfigFile(metaclass=ABCMeta):
         self._build_vars = []
         self._c_build_vars = []
         self._deps = {}
+        self._test_deps = {}
         self._with_source = True
         self._drop_unknown = True
         self._name = ''
@@ -85,6 +86,10 @@ class ConfigFile(metaclass=ABCMeta):
     @property
     def deps(self) -> dict:  # deps from config file. Dict of Dep, where keys are their names
         return self._deps
+
+    @property
+    def test_deps(self) -> dict:
+        return self._test_deps
 
     @property
     def prebuild(self) -> list:  # actions to be run before the build

--- a/coon/packages/config/coon.py
+++ b/coon/packages/config/coon.py
@@ -3,11 +3,21 @@ from os.path import join
 from tarfile import TarFile
 
 from coon.action.prebuild import action_factory
-
 from coon.compiler.compiler_type import Compiler
 from coon.packages.config.config import ConfigFile, get_dep_info_from_hex
 from coon.packages.dep import Dep
 from coon.utils.file_utils import read_file
+
+
+def parse_deps(deps: list) -> dict:
+    found = {}
+    for dep in deps:
+        name = dep['name']
+        if 'url' not in dep:
+            found[name] = get_dep_info_from_hex(name, dep['tag'])
+        else:
+            found[name] = Dep(dep['url'], dep.get('branch', None), tag=dep.get('tag', None))
+    return found
 
 
 class CoonConfig(ConfigFile):
@@ -18,7 +28,8 @@ class CoonConfig(ConfigFile):
         self._with_source = config.get('with_source', True)
         self.__parse_prebuild(config)
         self.__parse_build_vars(config)
-        self.__parse_deps(config.get('deps', {}))
+        self._deps = parse_deps(config.get('deps', {}))
+        self._test_deps = parse_deps(config.get('test_deps', {}))
         self._conf_vsn = config.get('app_vsn', None)
         self._git_vsn = config.get('tag', None)
         self._git_branch = config.get('branch', None)
@@ -42,14 +53,6 @@ class CoonConfig(ConfigFile):
 
     def get_compiler(self):
         return Compiler.COON
-
-    def __parse_deps(self, deps: list):
-        for dep in deps:
-            name = dep['name']
-            if 'url' not in dep:
-                self.deps[name] = get_dep_info_from_hex(name, dep['tag'])
-            else:
-                self.deps[name] = Dep(dep['url'], dep.get('branch', None), tag=dep.get('tag', None))
 
     def __parse_prebuild(self, parsed):
         for step in parsed.get('prebuild', []):

--- a/coon/packages/package.py
+++ b/coon/packages/package.py
@@ -22,6 +22,7 @@ class Package:
         self._path = path
         self._has_nifs = has_nifs
         self._deps = []
+        self._test_deps = []
         self.__set_deps()
         self.__set_url_from_git()
         self.__set_git_vsn()
@@ -75,6 +76,10 @@ class Package:
     @property
     def deps(self) -> list:  # package's deps.
         return self._deps
+
+    @property
+    def test_deps(self) -> list:
+        return self._test_deps
 
     @property
     def std_apps(self) -> list:  # standard erlang apps. Used in app.src templates
@@ -186,6 +191,8 @@ class Package:
         if self.config:  # TODO check config.drop_unknown (if not a template)
             for name, dep in self.config.deps.items():
                 self._deps.append(Package.from_dep(name, dep))
+            for name, dep in self.config.test_deps.items():
+                self._test_deps.append(Package.from_dep(name, dep))
 
     def __set_url_from_git(self):
         if not self.url:

--- a/coon/packages/package_builder.py
+++ b/coon/packages/package_builder.py
@@ -1,7 +1,7 @@
+from os import listdir
 from os.path import join
 
 import os
-from os import listdir
 
 from coon.compiler.compiler_factory import get_compiler
 from coon.compiler.compiler_type import Compiler
@@ -81,8 +81,11 @@ class Builder:
         return compiler.common(log_dir)
 
     # Parse package config, download missing deps to /tmp
-    def populate(self):
-        self.__populate_deps(self.project.deps)
+    def populate(self, include_test_deps=False):
+        deps = self.project.deps
+        if include_test_deps:
+            deps += self.project.test_deps
+        self.__populate_deps(deps)
 
     def add_package(self, remote: str, rewrite: bool, recurse: bool) -> bool:
         return self.system_config.cache.add_package(self.project, remote, rewrite, recurse)

--- a/test/abs_test_class.py
+++ b/test/abs_test_class.py
@@ -63,11 +63,11 @@ class TestClass(unittest.TestCase):
         remove_dir(test.get_test_dir(self.test_name))
 
 
-def set_deps(path: str, deps: list):
+def set_deps(path: str, deps: list, dep_type='deps'):
     fullpath = join(path, 'coonfig.json')
     with open(fullpath, 'r') as file:
         conf = json.load(file)
-    conf['deps'] = deps
+    conf[dep_type] = deps
     with open(fullpath, 'w') as file:
         json.dump(conf, file)
 


### PR DESCRIPTION
Deps are now splitted to `deps` and `test_deps` in coonfig.json.
Also erlang.mk test_deps are supported.
No test code should ever reach production.